### PR TITLE
リレーションメソッド名の修正

### DIFF
--- a/app/Models/Text.php
+++ b/app/Models/Text.php
@@ -16,7 +16,7 @@ class Text extends Model
 
     public $timestamps = false;
 
-    public function post()
+    public function posts()
     {
         return $this->hasMany(Post::class);
     }


### PR DESCRIPTION
リレーションメソッドの命名が間違っていたため。