### PR TITLE
シーダーの修正

### DIFF
--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use App\Models\Post;
 use App\Models\User;
+use Illuminate\Http\UploadedFile;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Post>
@@ -25,17 +26,21 @@ class PostFactory extends Factory
      */
     public function definition()
     {
-
+        // ランダムにレベルを選択
         $levels = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'];
         $level = $levels[rand(0, count($levels) - 1)];
+
+        // 拡張子をランダムに付与してファイルを生成
+        $mimes = ['.pdf', '.doc', '.zip', '.xls'];
+        $mime = $mimes[rand(0, count($mimes) - 1)];
+        $filePath = UploadedFile::fake()->create('fileName' . $mime, 30)->store('files', 'public');
 
         return [
             'title' => $this->faker->word(),
             'description' => $this->faker->realText(),
             'level' => $level,
             'user_id' => $this->faker->numberBetween(1, 3),
-            'file_name' => $this->faker->word(),
-
+            'file_name' => $filePath,
         ];
     }
 }


### PR DESCRIPTION
添付ファイルのダミーデータが入るように修正した。
 - 添付ファイル30件
 - 拡張子はdoc, zip, pdf, xlsの4種類からランダムで生成