### PR TITLE
シーダーでアップロードファイルを追加

### DIFF
--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -33,7 +33,7 @@ class PostFactory extends Factory
         // 拡張子をランダムに付与してファイルを生成
         $mimes = ['.pdf', '.doc', '.zip', '.xls'];
         $mime = $mimes[rand(0, count($mimes) - 1)];
-        $filePath = UploadedFile::fake()->create('fileName' . $mime, 30)->store('files', 'public');
+        $filePath = UploadedFile::fake()->create('fileName' . $mime)->store('files', 'public');
 
         return [
             'title' => $this->faker->word(),

--- a/database/migrations/2023_01_13_121341_create_posts_table.php
+++ b/database/migrations/2023_01_13_121341_create_posts_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
 
 return new class extends Migration
 {
@@ -33,5 +34,9 @@ return new class extends Migration
     public function down()
     {
         Schema::dropIfExists('posts');
+        // storage/app/public/fileディレクトリと、その中身の全削除
+        if (Storage::disk('public')->exists('files')) {
+            Storage::deleteDirectory('images');
+        }
     }
 };


### PR DESCRIPTION
シーディング時にstorage/app/public/files以下にファイルを追加する機能を実装（未完成）。
テーブル削除の際、アップロードされたファイルも同時に削除する機能を実装途中。