### PR TITLE
マイページの実装及びそれに伴う細かな部分の修正

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -162,14 +162,7 @@ class PostController extends Controller
         // アップロードされたファイルの削除
         \Storage::disk('public')->delete('files/' . $post->file_name);
 
-
-        // if (Request::routeIs('posts/*'))
-        // {
-        //     return redirect(route('posts.index'))->with('successMessage', '教案を削除しました。');
-        // } else
-        // {
-        //     return redirect(route('myposts.index'))->with('successMessage', '教案を削除しました。');
-        // }
+        return redirect(route('myposts.index'))->with('successMessage', '教案を削除しました。');
 
     }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -12,8 +12,12 @@ html, body {
     @apply flex items-center px-3 py-2 text-white font-bold leading-normal hover:border-b-2 hover:text-yellow-800 hover:bg-yellow-200 hover:border-yellow-900;
 }
 
-table.mytable th {
-    @apply px-6 py-4 text-lg text-left text-gray-100;
+table.table-index th {
+    @apply px-6 py-4 text-lg text-left text-gray-100 whitespace-nowrap;
+}
+
+table.table-index td {
+    @apply px-6 py-3 whitespace-nowrap;
 }
 
 .show-th {

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,15 +1,15 @@
 <nav class="sticky top-0 z-50 flex w-full h-16 bg-gradient-to-r from-orange-300 via-yellow-400 to-orange-400">
     <div class="flex items-stretch w-full h-full">
-        <div class="flex items-center h-full mx-2 shrink-0">
+        <div class="items-center hidden h-full md:mx-2 md:flex shrink-0">
             <a href="{{ route('posts.index') }}">
                 <x-application-logo class="block w-auto text-gray-800 fill-current h-9" />
             </a>
         </div>
-        {{-- レスポンシブメニュー --}}
-        <div class="flex items-center flex-grow md:hidden">
+        {{-- スマホ版レスポンシブメニュー --}}
+        <div class="flex items-center flex-grow ml-1 md:hidden">
             <x-dropdown class="h-full md:hidden" align="left">
                 <x-slot name="trigger" class="h-full">
-                    <x-primary-button class="h-full m-3 text-base bg-transparent rounded-lg md:hidden focus:bg-transparent focus:ring-transparent active:bg-yellow-100 focus:text-yellow-800" style="margin: 0px;">
+                    <x-primary-button class="h-full m-3 text-base bg-transparent rounded-lg md:hidden focus:bg-transparent focus:ring-transparent active:bg-yellow-100 focus:text-yellow-800" style="margin:0px;padding:2px 8px;">
                         <span class="text-2xl md:hidden"><i class="fa-sharp fa-solid fa-bars"></i></span>
                     </x-primary-button>
                 </x-slot>
@@ -23,6 +23,11 @@
                 @endif
                 </x-slot>
             </x-dropdown>
+            <div class="flex items-center h-full m-1 md:mx-2 shrink-0">
+                <a href="{{ route('posts.index') }}">
+                    <x-application-logo class="block w-auto text-gray-800 fill-current h-9" />
+                </a>
+            </div>
             <a href="#" class="flex items-center py-2 pl-1 text-base font-bold leading-normal text-white drop-shadow-lg">だてまき</a>
             <div class="flex items-stretch justify-end h-full ml-auto">
                 @if (Auth::check())

--- a/resources/views/myposts/index.blade.php
+++ b/resources/views/myposts/index.blade.php
@@ -1,17 +1,17 @@
 <x-app-layout>
     <x-slot name="header">じぶんの教案一覧</x-slot>
     <x-slot name="title">じぶんの教案</x-slot>
-    <div class="flex flex-col py-10">
-        <div class="inline-block min-w-full">
-            <table class="w-full border-b-2 table-fixed mytable">
+    <div class="flex flex-col p-2 md:py-10">
+        <div class="overflow-x-auto md:overflow-x-hidden">
+            <table class="border-b-2 table-fixed md:w-full table-index">
                 <thead class="bg-orange-300 border-b-2 border-gray-500">
                     <tr>
                         <div class="font-bold">
                             <th scope="col" class="w-1/12">♯</th>
-                            <th scope="col" class="w-6/12">タイトル</th>
+                            <th scope="col" class="w-5/12">タイトル</th>
                             <th scope="col" class="w-2/12">レベル</th>
                             <th scope="col" class="w-2/12">投稿日</th>
-                            <th scope="col" class="w-2/12">操作</th>
+                            <th scope="col" class="w-2/12"></th>
                         </div>
                     </tr>
                 </thead>
@@ -22,26 +22,16 @@
                         @else
                         <tr class="bg-white border-b hover:cursor-pointer hover:bg-yellow-100" data-href="{{ route('posts.show', $post) }}">
                         @endif
-                                <td class="px-6 py-3 font-medium truncate">{{ $loop->index + 1 }}</td>
-                                <td class="px-6 py-3 font-light truncate">{{ $post->title }}</td>
-                                <td class="px-6 py-3 font-light truncate">{{ $post->level }}</td>
-                                <td class="px-6 py-3 font-light truncate">{{ $post->created_at->format('Y/m/d') }}</td>
-                                <td class="px-6 py-3 font-light truncate">
-                                    <div class="flex">
-                                        <a href="{{ route('posts.edit', $post) }}" class="mr-5 text-sm leading-6 text-blue-400 hover:text-blue-700 hover:underline">編集</a>
-                                        {{-- <a href="route('posts.edit', $post)" class="text-sm text-red-400 hover:text-red-700 hover:underline">削除</a> --}}
-                                        <form onsubmit="return confirm('本当に削除しますか？')" action="{{ route('posts.destroy', $post) }}" method="POST">
-                                            @csrf
-                                            @method('DELETE')
-                                            <button class="text-sm leading-6 text-red-400 hover:text-red-700 hover:underline">削除</button>
-                                        </form>
-                                    </div>
-                                </td>
+                                <td class="font-medium truncate">{{ $loop->index + 1 }}</td>
+                                <td class="font-light truncate">{{ $post->title }}</td>
+                                <td class="font-light truncate">{{ $post->level }}</td>
+                                <td class="font-light truncate">{{ $post->created_at->format('Y/m/d') }}</td>
+                                <td class="font-light truncate"></td>
                         </tr>
                     @empty
                     <tr>
                         <td></td>
-                        <td class="px-6 py-3">教案が投稿されていません。みんなにシェアしてみましょう！</td>
+                        <td>教案が投稿されていません。みんなにシェアしてみましょう！</td>
                     </tr>
                     @endforelse
                 </tbody>

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -5,7 +5,7 @@
             <x-form :texts="$texts" :post="$post" />
             <div class="flex justify-center py-5">
                 <x-primary-button type="submit" class="mr-12 bg-orange-400 shadow-md hover:bg-orange-300">投稿する</x-primary-button>
-                <x-secondary-button onclick="location.href='{{ route('posts.index') }}'">キャンセル</x-secondary-button>
+                <x-secondary-button onclick="location.href='{{ route('myposts.index') }}'">キャンセル</x-secondary-button>
             </div>
         </form>
     </div>

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -1,14 +1,14 @@
 <x-app-layout>
     <x-slot name="header">教案一覧</x-slot>
-    <div class="flex flex-col py-10">
-        <div class="inline-block min-w-full">
-            <table class="w-full border-b-2 table-fixed mytable">
-                <thead class="bg-orange-300 border-b-2 border-gray-500">
-                    <tr>
+    <div class="flex flex-col p-2 md:py-10">
+        <div class="overflow-x-auto md:overflow-x-hidden">
+            <table class="border-b-2 table-fixed lg:w-full table-index">
+                <thead class="bg-orange-300 border-b-2 border-gray-500 ">
+                    <tr class="text-sm lg:text-lg">
                         <div class="font-bold">
                             <th scope="col" class="w-1/12">♯</th>
-                            <th scope="col" class="w-6/12">タイトル</th>
-                            <th scope="col" class="w-2/12">レベル</th>
+                            <th scope="col" class="w-3/12 lg:w-5/12">タイトル</th>
+                            <th scope="col" class="w-2/12 lg:w-2/12">レベル</th>
                             <th scope="col" class="w-2/12">投稿者</th>
                             <th scope="col" class="w-2/12">投稿日</th>
                         </div>
@@ -21,16 +21,16 @@
                         @else
                         <tr class="bg-white border-b hover:cursor-pointer hover:bg-yellow-100" data-href="{{ route('posts.show', $post) }}">
                         @endif
-                                <td class="px-6 py-3 font-medium truncate">{{ $loop->index + 1 }}</td>
-                                <td class="px-6 py-3 font-light truncate">{{ $post->title }}</td>
-                                <td class="px-6 py-3 font-light truncate">{{ $post->level }}</td>
-                                <td class="px-6 py-3 font-light truncate">{{ $post->user->name }}</td>
-                                <td class="px-6 py-3 font-light truncate">{{ $post->created_at->format('Y/m/d') }}</td>
+                                <td class="font-medium truncate">{{ $loop->index + 1 }}</td>
+                                <td class="font-light truncate">{{ $post->title }}</td>
+                                <td class="font-light truncate">{{ $post->level }}</td>
+                                <td class="font-light truncate">{{ $post->user->name }}</td>
+                                <td class="font-light truncate">{{ $post->created_at->format('Y/m/d') }}</td>
                         </tr>
                     @empty
                     <tr>
                         <td></td>
-                        <td class="px-6 py-3">まだ教案が投稿されていません。</td>
+                        <td>まだ教案が投稿されていません。</td>
                     </tr>
                     @endforelse
                 </tbody>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,12 +1,10 @@
 <x-app-layout>
     <x-slot name="header">教案詳細</x-slot>
-    <div class="w-full px-3 py-8 md:p-10">
-        <x-primary-button onclick="location.href='{{ route('posts.index') }}'">戻る</x-primary-button>
-        <div class="py-2 mb-2 mt-7">
-            <h1 class="p-1 text-2xl lg:text-4xl">{{ $post->title }}</h1>
+    <div class="w-full px-3 pt-8 pb-12 md:pt-10 md:pb-16">
+        <div class="mb-5">
+            <h1 class="pl-1 text-2xl lg:text-4xl">{{ $post->title }}</h1>
         </div>
         <table class="container w-full border-collapse md:text-left md:table-fixed">
-            {{-- TODO:table-cellでずれるので修正 --}}
             <tbody>
                 <tr class="show-tr">
                     <th class="w-full show-th md:w-1/5">レベル</th>


### PR DESCRIPTION
マイページ（じぶんの教案一覧画面）の完成に伴い、下記を変更した。
 - 詳細画面の戻るボタンを削除、ページ遷移が複雑になるのを防ぐ＆利用率の低いことが予想されるため。
 - 削除ボタン押下後の遷移先を、マイページに統一。
 - 教案一覧画面（みんなの教案、マイページ）のテーブルのレスポンシブ対応
 - navbarにおける、ハンバーガーとロゴの位置を変更した（ハンバーガーの押しやすさを重視）。