### PR TITLE
[fix]教案一覧画面、未ログインの場合のブックマークサインの非表示

### DIFF
--- a/resources/views/components/index-cards.blade.php
+++ b/resources/views/components/index-cards.blade.php
@@ -29,7 +29,7 @@
                 </div>
             </div>
             {{-- ブックマーク済みであれば、印を表示 --}}
-            @if (Auth::user()->is_bookmarked($post->id))
+            @if (Auth::check()&&Auth::user()->is_bookmarked($post->id))
                 <span><i class="text-orange-400 fa-solid fa-bookmark"></i></i></span>
             @endif
         </div>


### PR DESCRIPTION
未ログインの場合でもブックマークサイン表示のメソッドが呼び出され、エラーが出ていたので修正。