### PR TITLE
Feature

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -18,7 +18,8 @@ class UserController extends Controller
         // 検索フォームに入力された値を取得
         $keyword = $request->user_name_keyword;
 
-        $query = User::latest();
+        // roleカラムに'user'の値を持つユーザーのみを取得する
+        $query = User::where('role', 'user')->latest();
 
         // キーワードで検索をしたときだけ実行
         if ($keyword)

--- a/app/Http/Requests/StorePostRequest.php
+++ b/app/Http/Requests/StorePostRequest.php
@@ -26,14 +26,14 @@ class StorePostRequest extends FormRequest
     {
         $rules = [
             'title' => 'required|max:255',
-            'description' => 'required|max:1000',
+            'description' => 'required',
             'level' => ['required', Rule::in(['A1', 'A2', 'B1', 'B2', 'C1', 'C2'])],
             'file_name' => [
                 'file',
                 // 拡張子
-                'mimes:pdf,doc,zip,xls,',
+                'mimes:pdf,docx,zip,xlsx,jpeg,jpg,png',
                 // MIMEタイプ：Word, Excel, Zip, PDF
-                'mimetypes:application/pdf,application/msword,application/zip,application/msexcel',
+                'mimetypes:application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/zip,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,image/jpeg,image/png',
             ],
             'text_id' => 'nullable|exists:texts,id',
         ];

--- a/app/Http/Requests/StorePostRequest.php
+++ b/app/Http/Requests/StorePostRequest.php
@@ -24,10 +24,6 @@ class StorePostRequest extends FormRequest
      */
     public function rules()
     {
-
-        // アクションの名前を取得する
-        $action = $this->route()->getName();
-
         $rules = [
             'title' => 'required|max:255',
             'description' => 'required|max:1000',
@@ -35,18 +31,12 @@ class StorePostRequest extends FormRequest
             'file_name' => [
                 'file',
                 // 拡張子
-                'mimes:pdf,doc,zip,xls',
+                'mimes:pdf,doc,zip,xls,',
                 // MIMEタイプ：Word, Excel, Zip, PDF
                 'mimetypes:application/pdf,application/msword,application/zip,application/msexcel',
             ],
             'text_id' => 'nullable|exists:texts,id',
         ];
-
-        // 投稿処理の際に、file_nameを入力必須にする
-        if ($action ==='posts.store')
-        {
-            $rules['file_name'][] = 'required';
-        }
 
         return $rules;
     }

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -32,7 +32,7 @@ class PostFactory extends Factory
 
         // 拡張子をランダムに付与してファイルを生成
         // ファイル名は重複を避けるため、time()ではなくfakerを使用
-        $exts = ['pdf', 'doc', 'zip', 'xls'];
+        $exts = ['pdf', 'docx', 'zip', 'xlsx', 'jpeg', 'jpg', 'png'];
         $ext = $exts[rand(0, count($exts) - 1)];
         $fileName = $this->faker->word() . '.' . $ext;
         UploadedFile::fake()->create($fileName)->storeAs('public/files', $fileName);
@@ -44,14 +44,23 @@ class PostFactory extends Factory
             case 'pdf':
                 $mimetype = 'application/pdf';
                 break;
-            case 'doc':
-                $mimetype = 'application/msword';
+            case 'docx':
+                $mimetype = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
                 break;
             case 'zip':
                 $mimetype = 'application/zip';
                 break;
-            case 'xls':
-                $mimetype = 'application/vnd.ms-excel';
+            case 'xlsx':
+                $mimetype = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+                break;
+            case 'jpeg':
+                $mimetype = 'image/jpeg';
+                break;
+            case 'jpg':
+                $mimetype = 'image/jpeg';
+                break;
+            case 'png':
+                $mimetype = 'image/png';
                 break;
         }
 
@@ -59,7 +68,8 @@ class PostFactory extends Factory
             'title' => $this->faker->word(),
             'description' => $this->faker->realText(),
             'level' => $level,
-            'user_id' => $this->faker->numberBetween(1, 3),
+            // user_id=1はゲストユーザー、user_id=2は管理者のため除外。
+            'user_id' => $this->faker->numberBetween(3, 5),
             'file_name' => $fileName,
             'file_mimetype' => $mimetype,
             'file_size' => 0,

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -18,9 +18,9 @@ return new class extends Migration
             $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
-            $table->enum('role', ['admin', 'guest', 'user'])->default('user'); //admin=管理者、guest=ゲストユーザー、user=一般ユーザ
-            $table->string('password');
+            $table->enum('role', ['admin', 'guest', 'user'])->default('user'); //admin=管理者、guest=ゲストユーザー、user=一般ユーザー
             $table->string('profile_image')->nullable();
+            $table->string('password');
             $table->rememberToken();
             $table->timestamps();
         });

--- a/database/migrations/2023_01_13_121341_create_posts_table.php
+++ b/database/migrations/2023_01_13_121341_create_posts_table.php
@@ -19,9 +19,9 @@ return new class extends Migration
             $table->text('description');
             $table->enum('level', ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'])->default('A1');
             $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
-            $table->string('file_name');
-            $table->string('file_mimetype');
-            $table->bigInteger('file_size');
+            $table->string('file_name')->nullable();
+            $table->string('file_mimetype')->nullable();
+            $table->bigInteger('file_size')->nullable();
             $table->foreignId('text_id')->nullable()->constrained('texts');
             $table->timestamps();
         });

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -24,7 +24,7 @@ table.table-index td {
 }
 
 .show-td {
-    @apply p-4 border-t-2 border-l-2 border-r-2 md:border-2 border-gray-300 border-solid bg-gray-50 text-center md:text-left;
+    @apply p-4 border-t-2 border-l-2 border-r-2 md:border-2 border-gray-300 border-solid bg-gray-50 text-center md:text-left break-all;
 }
 
 .show-tr {

--- a/resources/views/components/form.blade.php
+++ b/resources/views/components/form.blade.php
@@ -51,7 +51,9 @@
     <x-input-error :messages="$errors->get('description')" class="mt-2" />
 </div>
 <div class="form-group">
-    <label for="file" class="block text-lg">添付ファイル</label>
+    <label for="file" class="block mb-3 text-lg">添付ファイル
+        <span class="p-1 ml-3 text-base bg-orange-200 rounded-md">形式&nbsp;:&nbsp;pdf,&nbsp;docx,&nbsp;zip,&nbsp;xlsx,&nbsp;jpeg,&nbsp;jpg,&nbsp;png</span>
+    </label>
     @if (isset($post->file_name))
         <div class="flex my-2 ml-2 text-sm">
             <p class="mr-4">現在のファイル&nbsp;:&nbsp;{{ $post->file_name}}</p>

--- a/resources/views/components/index-cards.blade.php
+++ b/resources/views/components/index-cards.blade.php
@@ -38,7 +38,7 @@
                 <span><i class="text-orange-400 fa-solid fa-bookmark"></i></i></span>
             @endif
         </div>
-        <p class="h-16 m-3 mt-0 text-base font-normal leading-snug text-gray-500 line-clamp-3">{{ $post->description }}</p>
+        <p class="h-16 m-3 mt-0 text-base font-normal leading-snug text-gray-500 break-all line-clamp-3">{{ $post->description }}</p>
         <p class="ml-auto text-xs font-light text-gray-400">{{ $post->updated_at->format('Y/m/d') }}</p>
     </div>
     @endforeach

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -50,15 +50,40 @@
                 </tr>
                 <tr class="show-tr">
                     <th class="show-th">添付ファイル</th>
-                    <td class="show-td hover:underline"><a href="{{ $post->file_url }}" target="_blank" rel="noopener noreferrer">{{ $post->file_name }}</a></td>
+                    @if(isset($post->file_name))
+                    <td class="show-td">
+                        <a href="{{ $post->file_url }}" target="_blank" rel="noopener noreferrer">
+                            <span class="text-blue-500 hover:underline">{{ $post->file_name }}</span>
+                        </a>
+                        <button onclick="location.href='{{ $post->file_url }}'" class="inline-flex items-center justify-center px-4 py-2 ml-3 text-xs font-semibold tracking-widest text-white uppercase transition duration-150 ease-in-out bg-blue-500 border border-transparent rounded-md shadow-md hover:bg-blue-300 focus:bg-blue-300 active:bg-blue-500 focus:outline-none">
+                            @if ($post->file_mimetype === 'application/pdf')
+                            <span><i class="mr-2 fa-solid fa-arrow-up-right-from-square" style="color: #ffffff;"></i></span>
+                            <span>表示</span>
+                            @else
+                            <span><i class="mr-2 fa-solid fa-arrow-down" style="color: #ffffff;"></i></span>
+                            <span>ダウンロード</span>
+                            @endif
+                        </button>
+                    </td>
+                    @else
+                    <td class="show-td">&ensp;-</td>
+                    @endif
                 </tr>
                 <tr class="show-tr">
                     <th class="show-th">ファイルサイズ</th>
+                    @if(isset($post->file_size))
                     <td class="show-td">{{ $post->file_size }}</td>
+                    @else
+                    <td class="show-td">&ensp;-</td>
+                    @endif
                 </tr>
                 <tr class="show-tr">
                     <th class="show-th">MIMEタイプ</th>
+                    @if(isset($post->file_mimetype))
                     <td class="show-td">{{ $post->file_mimetype }}</td>
+                    @else
+                    <td class="show-td">&ensp;-</td>
+                    @endif
                 </tr>
                 <tr class="show-tr">
                     <th class="show-th">投稿日</th>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -55,15 +55,15 @@
                         <a href="{{ $post->file_url }}" target="_blank" rel="noopener noreferrer">
                             <span class="text-blue-500 hover:underline">{{ $post->file_name }}</span>
                         </a>
-                        <button onclick="location.href='{{ $post->file_url }}'" class="inline-flex items-center justify-center px-4 py-2 ml-3 text-xs font-semibold tracking-widest text-white uppercase transition duration-150 ease-in-out bg-blue-500 border border-transparent rounded-md shadow-md hover:bg-blue-300 focus:bg-blue-300 active:bg-blue-500 focus:outline-none">
-                            @if ($post->file_mimetype === 'application/pdf')
+                        <a href="{{ $post->file_url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center px-4 py-2 ml-3 text-xs font-semibold tracking-widest text-white uppercase transition duration-150 ease-in-out bg-blue-500 border border-transparent rounded-md shadow-md hover:bg-blue-300 focus:bg-blue-500 active:bg-blue-300 focus:outline-none">
+                            @if ($post->file_mimetype === 'application/pdf' || $post->file_mimetype === 'image/jpeg' || $post->file_mimetype === 'image/png')
                             <span><i class="mr-2 fa-solid fa-arrow-up-right-from-square" style="color: #ffffff;"></i></span>
                             <span>表示</span>
                             @else
                             <span><i class="mr-2 fa-solid fa-arrow-down" style="color: #ffffff;"></i></span>
                             <span>ダウンロード</span>
                             @endif
-                        </button>
+                        </a>
                     </td>
                     @else
                     <td class="show-td">&ensp;-</td>


### PR DESCRIPTION
その他の修正点
 - 詳細画面のテーブルまたは一覧画面のカードからのはみ出しを防ぐため、英文字を単語途中でも折り返すようにCSS適用。
 - 投稿における、概要の文字数制限をなくした。
 - 添付できるファイルの拡張子の種類を、pdf, zip, docx, xlsx, jpeg, jpg, pngの6種類へ変更
 - 拡張子の変更に伴い、ファクトリで作成する初期データの変更
