### PR TITLE
[feat]投稿の添付ファイルが画像の場合は詳細画面に表示する

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -227,22 +227,4 @@ class PostController extends Controller
 
         return view('posts.bookmarks', $data);
     }
-
-    /**
-     * ファイルをダウンロードする.
-     *
-     * @param \App\Models\Post  $post
-     * @return \Illuminate\Http\Response
-     */
-    public function downloadFile(Post $post)
-    {
-        $filePath = $post->file_url;
-        $fileName = $post->file_name;
-        $mimetype = Storage::mimeType($filePath);  //ここで$mimetypeがfalseになる。
-        // $mimetype = $post->file_mimetype; // この記述でもうまくいかなかった。
-
-        $headers = [['Content-Type' => $mimetype]];
-
-        return Storage::download($filePath, $fileName, $headers);
-    }
 }

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -59,20 +59,25 @@
                         <div class="flex flex-col items-center justify-center md:justify-start md:flex-row">
                             <a href="{{ $post->file_url }}" target="_blank" rel="noopener noreferrer">
                                 <span class="text-blue-500 hover:underline">{{ $post->file_name }}</span>
+                                @if ($post->file_mimetype === 'image/jpeg' || $post->file_mimetype === 'image/png' || $post->file_mimetype === 'application/pdf')
+                                <span><i class="fa-solid fa-arrow-up-right-from-square" style="color: #3b82f6;"></i></span>
+                                @endif
                             </a>
                             <div class="md:ml-6">
-                                {{-- 画像、PDFなら表示ボタンを表示 --}}
-                                @if ($post->file_mimetype === 'application/pdf' || $post->file_mimetype === 'image/jpeg' || $post->file_mimetype === 'image/png')
-                                <a href="{{ $post->file_url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center px-4 py-2 text-xs font-semibold tracking-widest text-white uppercase transition duration-150 ease-in-out bg-gray-400 border border-transparent rounded-md shadow-md hover:bg-gray-300 focus:bg-gray-400 active:bg-gray-300 focus:outline-none">
+                                {{-- {{ 画像であれば画像を表示 }} --}}
+                                @if ($post->file_mimetype === 'image/jpeg' || $post->file_mimetype === 'image/png')
+                                <img src="{{ $post->file_url }}">
+                                {{-- PDFであれば表示ボタンを表示 --}}
+                                @elseif ($post->file_mimetype === 'application/pdf')
+                                <a href="{{ $post->file_url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center px-4 py-2 text-xs font-semibold tracking-widest text-white uppercase transition duration-150 ease-in-out bg-blue-500 border border-transparent rounded-md shadow-md hover:bg-blue-300 focus:bg-blue-500 active:bg-blue-300 focus:outline-none">
                                     <span><i class="mr-2 fa-solid fa-arrow-up-right-from-square" style="color: #ffffff;"></i></span>
                                     <span>表示</span>
                                 </a>
-                                @endif
-                                {{-- <a href="{{ $post->file_url }}" download class="inline-flex items-center justify-center px-4 py-2 mt-2 text-xs font-semibold tracking-widest text-white uppercase transition duration-150 ease-in-out bg-blue-500 border border-transparent rounded-md shadow-md sm:ml-3 hover:bg-blue-300 focus:bg-blue-500 active:bg-blue-300 focus:outline-none md:mt-0">
-                                    <span><i class="mr-2 fa-solid fa-arrow-down" style="color: #ffffff;"></i></span> --}}
-                                <a href="{{ route('posts.download', $post) }}" class="inline-flex items-center justify-center px-4 py-2 mt-2 text-xs font-semibold tracking-widest text-white uppercase transition duration-150 ease-in-out bg-blue-500 border border-transparent rounded-md shadow-md sm:ml-3 hover:bg-blue-300 focus:bg-blue-500 active:bg-blue-300 focus:outline-none md:mt-0">
-                                    <span><i class="mr-2 fa-solid fa-arrow-down" style="color: #ffffff;"></i></span>
+                                @else
+                                <a href="{{ $post->file_url }}" download class="inline-flex items-center justify-center px-4 py-2 mt-2 text-xs font-semibold tracking-widest text-white uppercase transition duration-150 ease-in-out bg-blue-500 border border-transparent rounded-md shadow-md hover:bg-blue-300 focus:bg-blue-500 active:bg-blue-300 focus:outline-none">
+                                    <span><i class="mr-2 fa-solid fa-download" style="color: #ffffff;"></i></span>
                                     <span>ダウンロード</span>
+                                @endif
                                 </a>
                             </div>
                         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,7 +38,6 @@ Route::middleware('auth')->group(function () {
     Route::delete('/posts/{post}/unbookmark', [BookmarkController::class, 'destroy'])->name('bookmarks.destroy');
     Route::post('/posts/{post}/bookmark', [BookmarkController::class, 'store'])->name('bookmarks.store');
     Route::get('/bookmarks', [PostController::class, 'bookmark_posts'])->name('bookmarks');
-    Route::get('/posts/{post}/download', [PostController::class, 'downloadFile'])->name('posts.download');
 });
 
 Route::resource('/posts', PostController::class);


### PR DESCRIPTION
その他、 ダウンロードボタンは、拡張子がdocx, xlsxの場合のみ表示するように変更。
（その他は別タブで開けばダウンロード可能なため）